### PR TITLE
run lint and format

### DIFF
--- a/frontend/packages/volto-workflow-manager/src/components/Controlpanel/WorkflowTable.tsx
+++ b/frontend/packages/volto-workflow-manager/src/components/Controlpanel/WorkflowTable.tsx
@@ -235,11 +235,7 @@ const WorkflowTable = ({ workflows, handleWorkflowClick, isClickable }) => {
               >
                 Cancel
               </Button>
-              <Button
-                variant="negative"
-                style="fill"
-                onPress={handleConfirmDelete}
-              >
+              <Button variant="negative" onPress={handleConfirmDelete}>
                 Delete
               </Button>
             </ButtonGroup>

--- a/frontend/packages/volto-workflow-manager/src/components/Graph/Nodes/index.css
+++ b/frontend/packages/volto-workflow-manager/src/components/Graph/Nodes/index.css
@@ -1,13 +1,13 @@
 /* Custom Node Styles */
 .custom-node {
+  position: relative;
+  min-width: 100px;
   padding: 10px 15px;
   border: 2px solid #ddd;
   border-radius: 8px;
   background: white;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  min-width: 100px;
   transition: all 0.2s ease;
-  position: relative;
 }
 
 .custom-node:hover {
@@ -22,14 +22,14 @@
 
 /* Node content layout */
 .node-content {
-  text-align: center;
   line-height: 1.4;
+  text-align: center;
 }
 
 .node-description {
-  font-size: 11px;
-  color: #666;
   margin-top: 4px;
+  color: #666;
+  font-size: 11px;
   font-weight: normal;
 }
 
@@ -57,8 +57,8 @@
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .custom-node {
-    padding: 8px 12px;
     min-width: 80px;
+    padding: 8px 12px;
   }
 
   .node-description {

--- a/frontend/packages/volto-workflow-manager/src/components/Workflow/WorkflowTab.tsx
+++ b/frontend/packages/volto-workflow-manager/src/components/Workflow/WorkflowTab.tsx
@@ -40,10 +40,6 @@ const WorkflowTab: React.FC<WorkflowTabProps> = ({
     (state: GlobalRootState) => state.workflow.workflow.currentWorkflow,
   );
 
-  const loading = useSelector(
-    (state: GlobalRootState) => state.workflow.workflow.loading,
-  );
-
   const [formData, setFormData] = useState<{
     title: string;
     description: string;


### PR DESCRIPTION
Fixes #15 

I ran `make lint` and `make format` to solve most of the errors. Still getting this
```
C901 `reply` is too complex (11 > 10)
   --> src/workflow/manager/api/services/workflow/workflow.py:329:9
    |
327 |         return self
328 |
329 |     def reply(self):
    |         ^^^^^
330 |         if not self.params:
331 |             self.request.response.setStatus(400)
```

Not sure what to do with style prop. It doesn't get fixed even after creating an object